### PR TITLE
fix(transcribe): Update audio resource handling

### DIFF
--- a/src/main/java/org/ping_me/service/ai/transcribe/impl/SpeechToTextServiceImpl.java
+++ b/src/main/java/org/ping_me/service/ai/transcribe/impl/SpeechToTextServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.ping_me.service.ai.transcribe.SpeechToTextService;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
@@ -45,10 +46,12 @@ public class SpeechToTextServiceImpl implements SpeechToTextService {
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
 
         // Resource từ file upload
-        InputStreamResource fileResource = new InputStreamResource(audioFile.getInputStream()) {
+        byte[] fileBytes = audioFile.getBytes(); // Đọc file vào RAM
+        ByteArrayResource fileResource = new ByteArrayResource(fileBytes) {
             @Override
             public String getFilename() {
-                return audioFile.getOriginalFilename() != null ? audioFile.getOriginalFilename() : "audio.webm";
+                String originalName = audioFile.getOriginalFilename();
+                return StringUtils.hasText(originalName) ? originalName : "audio.webm";
             }
         };
 


### PR DESCRIPTION
Updated SpeechToTextServiceImpl to use ByteArrayResource for audio file handling, improving how multipart file data is managed during transcription. This change uses `getBytes()` and `ByteArrayResource` instead of `InputStreamResource` to ensure the file content is read into RAM once for reliability.