### PR TITLE
fix(message): Persist message recall explicitly for Mongo

### DIFF
--- a/src/main/java/org/ping_me/service/chat/impl/MessageServiceImpl.java
+++ b/src/main/java/org/ping_me/service/chat/impl/MessageServiceImpl.java
@@ -334,6 +334,9 @@ public class MessageServiceImpl implements MessageService {
         // Xóa content
         messageToRecall.setContent("");
 
+        // Mongo document does not use JPA dirty checking, so persist the recall explicitly.
+        messageRepository.save(messageToRecall);
+
         // ---------------------------
         // UPDATE CACHE
         // ---------------------------


### PR DESCRIPTION
The message recall logic in MessageServiceImpl.java was updated to explicitly save the modified message document to the MongoDB repository. This ensures that the recall status (isActive=false and empty content) is persisted, as MongoDB documents do not automatically use JPA dirty checking for updates.