### PR TITLE
feat(chat): Implement message editing functionality

### DIFF
--- a/src/main/java/org/ping_me/controller/chat/MessageController.java
+++ b/src/main/java/org/ping_me/controller/chat/MessageController.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.ping_me.dto.base.ApiResponse;
 import org.ping_me.dto.request.chat.message.ForwardMessageRequest;
 import org.ping_me.dto.request.chat.message.ForwardMessagesRequest;
+import org.ping_me.dto.request.chat.message.EditMessageRequest;
 import org.ping_me.dto.request.chat.message.MarkReadRequest;
 import org.ping_me.dto.response.chat.message.DeletedMessageResponse;
 import org.ping_me.dto.request.chat.message.SendMessageRequest;
@@ -206,6 +207,23 @@ public class    MessageController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(new ApiResponse<>(messageService.deleteMessageForMe(id)));
+    }
+
+    @Operation(
+            summary = "Chỉnh sửa tin nhắn",
+            description = "Chỉnh sửa nội dung một tin nhắn văn bản đã gửi"
+    )
+    @PatchMapping("/{id}")
+    public ResponseEntity<ApiResponse<MessageResponse>> editMessage(
+            @Parameter(description = "ID tin nhắn", example = "msg_123", required = true)
+            @PathVariable String id,
+
+            @Parameter(description = "Payload chỉnh sửa tin nhắn", required = true)
+            @RequestBody @Valid EditMessageRequest editMessageRequest
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new ApiResponse<>(messageService.editMessage(id, editMessageRequest)));
     }
 
     // ================= MARK READ =================

--- a/src/main/java/org/ping_me/dto/request/chat/message/EditMessageRequest.java
+++ b/src/main/java/org/ping_me/dto/request/chat/message/EditMessageRequest.java
@@ -1,0 +1,20 @@
+package org.ping_me.dto.request.chat.message;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+/**
+ * Admin 4/16/2026
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class EditMessageRequest {
+
+    @NotBlank(message = "Nội dung không được để trống")
+    @Length(max = 1000, message = "Nội dung không được vượt quá 1000 ký tự")
+    private String content;
+}

--- a/src/main/java/org/ping_me/dto/response/chat/message/MessageResponse.java
+++ b/src/main/java/org/ping_me/dto/response/chat/message/MessageResponse.java
@@ -28,6 +28,8 @@ public class MessageResponse {
     private String fileFormat;
     private List<String> mediaUrls;
     private LocalDateTime createdAt;
+    private Boolean isEdited;
+    private LocalDateTime editedAt;
 
     private Boolean isActive;
     private Boolean isForwarded;

--- a/src/main/java/org/ping_me/model/chat/Message.java
+++ b/src/main/java/org/ping_me/model/chat/Message.java
@@ -79,6 +79,12 @@ public class Message {
     @Field("replied_message_id")
     String repliedMessageId;
 
+    @Field("is_edited")
+    Boolean isEdited = false;
+
+    @Field("edited_at")
+    LocalDateTime editedAt;
+
     @CreatedDate
     @Field("created_at")
     LocalDateTime createdAt;
@@ -101,5 +107,9 @@ public class Message {
 
     public boolean isForwarded() {
         return Boolean.TRUE.equals(isForwarded);
+    }
+
+    public boolean isEdited() {
+        return Boolean.TRUE.equals(isEdited);
     }
 }

--- a/src/main/java/org/ping_me/service/chat/MessageService.java
+++ b/src/main/java/org/ping_me/service/chat/MessageService.java
@@ -2,6 +2,7 @@ package org.ping_me.service.chat;
 
 import org.ping_me.dto.request.chat.message.ForwardMessageRequest;
 import org.ping_me.dto.request.chat.message.ForwardMessagesRequest;
+import org.ping_me.dto.request.chat.message.EditMessageRequest;
 import org.ping_me.dto.request.chat.message.MarkReadRequest;
 import org.ping_me.dto.request.chat.message.SendMessageRequest;
 import org.ping_me.dto.request.chat.message.SendWeatherMessageRequest;
@@ -47,6 +48,8 @@ public interface MessageService {
     List<MessageResponse> forwardMessages(ForwardMessagesRequest request);
 
     DeletedMessageResponse deleteMessageForMe(String messageId);
+
+    MessageResponse editMessage(String messageId, EditMessageRequest request);
 
     MessageRecalledResponse recallMessage(String messageId);
 

--- a/src/main/java/org/ping_me/service/chat/event/message/MessageUpdatedEvent.java
+++ b/src/main/java/org/ping_me/service/chat/event/message/MessageUpdatedEvent.java
@@ -1,0 +1,19 @@
+package org.ping_me.service.chat.event.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.ping_me.model.chat.Message;
+
+/**
+ * Admin 4/16/2026
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class MessageUpdatedEvent {
+
+    private Message message;
+}

--- a/src/main/java/org/ping_me/service/chat/impl/MessageServiceImpl.java
+++ b/src/main/java/org/ping_me/service/chat/impl/MessageServiceImpl.java
@@ -11,6 +11,7 @@ import org.ping_me.config.s3.S3Service;
 import org.ping_me.dto.event.UserChatEvent;
 import org.ping_me.dto.request.chat.message.ForwardMessageRequest;
 import org.ping_me.dto.request.chat.message.ForwardMessagesRequest;
+import org.ping_me.dto.request.chat.message.EditMessageRequest;
 import org.ping_me.dto.request.chat.message.MarkReadRequest;
 import org.ping_me.dto.request.chat.message.SendMessageRequest;
 import org.ping_me.dto.request.chat.message.SendWeatherMessageRequest;
@@ -36,6 +37,7 @@ import org.ping_me.service.chat.MessageCachingService;
 import org.ping_me.service.chat.MessageService;
 import org.ping_me.service.chat.event.message.MessageCreatedEvent;
 import org.ping_me.service.chat.event.message.MessageRecalledEvent;
+import org.ping_me.service.chat.event.message.MessageUpdatedEvent;
 import org.ping_me.service.chat.event.room.RoomUpdatedEvent;
 import org.ping_me.service.user.CurrentUserProvider;
 import org.ping_me.service.weather.WeatherService;
@@ -449,6 +451,64 @@ public class MessageServiceImpl implements MessageService {
         }
 
         return new DeletedMessageResponse(messageId);
+    }
+
+    @Override
+    public MessageResponse editMessage(String messageId, EditMessageRequest request) {
+        var currentUser = currentUserProvider.get();
+
+        Message messageToEdit = messageRepository
+                .findById(messageId)
+                .orElseThrow(() -> new EntityNotFoundException("Không tìm thấy tin nhắn"));
+
+        if (!currentUser.getId().equals(messageToEdit.getSenderId())) {
+            throw new AccessDeniedException("Không có quyền truy cập");
+        }
+
+        if (!messageToEdit.isActive()) {
+            throw new IllegalArgumentException("Không thể chỉnh sửa tin nhắn đã thu hồi");
+        }
+
+        if (messageToEdit.getType() != MessageType.TEXT) {
+            throw new IllegalArgumentException("Chỉ hỗ trợ chỉnh sửa tin nhắn văn bản");
+        }
+
+        long hours = ChronoUnit.HOURS.between(messageToEdit.getCreatedAt(), LocalDateTime.now());
+        if (hours > 24) {
+            throw new IllegalArgumentException("Bạn chỉ có thể chỉnh sửa tin nhắn trong vòng 24 giờ");
+        }
+
+        String newContent = request.getContent().trim();
+        if (newContent.equals(messageToEdit.getContent())) {
+            return chatMapper.toMessageResponseDto(messageToEdit);
+        }
+
+        messageToEdit.setContent(newContent);
+        messageToEdit.setIsEdited(true);
+        messageToEdit.setEditedAt(LocalDateTime.now());
+        messageToEdit = messageRepository.save(messageToEdit);
+
+        var dto = chatMapper.toMessageResponseDto(messageToEdit);
+        if (cacheEnabled) {
+            messageCachingService.updateMessage(messageToEdit.getRoomId(), messageId, dto);
+        }
+
+        eventPublisher.publishEvent(new MessageUpdatedEvent(messageToEdit));
+
+        Room room = roomRepository
+                .findById(messageToEdit.getRoomId())
+                .orElseThrow(() -> new EntityNotFoundException("Phòng chat này không tồn tại"));
+
+        if (messageId.equals(room.getLastMessageId())) {
+            var roomUpdatedEvent = new RoomUpdatedEvent(
+                    room,
+                    roomParticipantRepository.findByRoom_Id(room.getId()),
+                    null
+            );
+            eventPublisher.publishEvent(roomUpdatedEvent);
+        }
+
+        return dto;
     }
 
     private Message validateForwardSourceMessage(String sourceMessageId, Long senderId) {

--- a/src/main/java/org/ping_me/utils/mapper/ChatMapper.java
+++ b/src/main/java/org/ping_me/utils/mapper/ChatMapper.java
@@ -53,6 +53,8 @@ public class ChatMapper {
                 message.getFileFormat(),
                 mediaUrls,
                 message.getCreatedAt(),
+                message.isEdited(),
+                message.getEditedAt(),
                 message.isActive(),
                 message.isForwarded(),
                 forwardMetadata,

--- a/src/main/java/org/ping_me/websocket/dto/chat/common/ChatEventType.java
+++ b/src/main/java/org/ping_me/websocket/dto/chat/common/ChatEventType.java
@@ -7,6 +7,7 @@ package org.ping_me.websocket.dto.chat.common;
 public enum ChatEventType {
     // Message
     MESSAGE_CREATED,
+    MESSAGE_UPDATED,
     MESSAGE_RECALLED,
     MESSAGE_TYPING,
     READ_STATE_CHANGED,

--- a/src/main/java/org/ping_me/websocket/dto/chat/message/MessageUpdatedEventPayload.java
+++ b/src/main/java/org/ping_me/websocket/dto/chat/message/MessageUpdatedEventPayload.java
@@ -1,0 +1,20 @@
+package org.ping_me.websocket.dto.chat.message;
+
+import lombok.Getter;
+import org.ping_me.dto.response.chat.message.MessageResponse;
+import org.ping_me.websocket.dto.chat.common.BaseChatEventPayload;
+import org.ping_me.websocket.dto.chat.common.ChatEventType;
+
+/**
+ * Admin 4/16/2026
+ */
+@Getter
+public class MessageUpdatedEventPayload extends BaseChatEventPayload {
+
+    private final MessageResponse messageResponse;
+
+    public MessageUpdatedEventPayload(MessageResponse messageResponse) {
+        super(ChatEventType.MESSAGE_UPDATED);
+        this.messageResponse = messageResponse;
+    }
+}

--- a/src/main/java/org/ping_me/websocket/publisher/ChatMessageEventPublisher.java
+++ b/src/main/java/org/ping_me/websocket/publisher/ChatMessageEventPublisher.java
@@ -4,10 +4,12 @@ import lombok.RequiredArgsConstructor;
 import org.ping_me.dto.response.chat.message.MessageRecalledResponse;
 import org.ping_me.service.chat.event.message.MessageCreatedEvent;
 import org.ping_me.service.chat.event.message.MessageRecalledEvent;
+import org.ping_me.service.chat.event.message.MessageUpdatedEvent;
 import org.ping_me.utils.mapper.ChatMapper;
 import org.ping_me.websocket.WebSocketDestinations;
 import org.ping_me.websocket.dto.chat.message.MessageCreatedEventPayload;
 import org.ping_me.websocket.dto.chat.message.MessageRecalledEventPayload;
+import org.ping_me.websocket.dto.chat.message.MessageUpdatedEventPayload;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -39,6 +41,17 @@ public class ChatMessageEventPublisher {
         redisWsPublisher.publish(
                 WebSocketDestinations.roomMessagesTopic(event.getRoomId()),
                 payload
+        );
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onMessageUpdated(MessageUpdatedEvent event) {
+        var messageResponse = chatMapper.toMessageResponseDto(event.getMessage());
+        var roomId = event.getMessage().getRoomId();
+
+        redisWsPublisher.publish(
+                WebSocketDestinations.roomMessagesTopic(roomId),
+                new MessageUpdatedEventPayload(messageResponse)
         );
     }
 }


### PR DESCRIPTION
Adds new API endpoint, service logic, and websocket event for editing chat messages.
- Introduces `MESSAGE_UPDATED` event type for real-time notification.
- Updates `Message` model to track `isEdited` status and `editedAt` timestamp.
- Allows users to modify text messages within 24 hours of sending.