### PR TITLE
feat(call): Implement signaling service with Redis

### DIFF
--- a/src/main/java/org/ping_me/controller/call/SignalingController.java
+++ b/src/main/java/org/ping_me/controller/call/SignalingController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.ping_me.dto.request.call.SignalingRequest;
-import org.ping_me.service.call.impl.SignalingServiceImpl;
+import org.ping_me.service.call.SignalingService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,18 +25,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class SignalingController {
 
-    private final SignalingServiceImpl signalingService;
+    private final SignalingService signalingService;
 
     // ================= SIGNAL =================
     @Operation(
             summary = "Gửi tín hiệu cuộc gọi",
             description = """
-                    Gửi signaling message phục vụ thiết lập / duy trì cuộc gọi realtime.
-                    Dùng cho các loại tín hiệu như:
-                    - offer
-                    - answer
-                    - ice-candidate
-                    """
+        Gửi signaling message để thiết lập / điều phối cuộc gọi realtime qua Zego.
+        Các loại tín hiệu hỗ trợ:
+        - INVITE  : Mời người dùng vào cuộc gọi
+        - ACCEPT  : Chấp nhận cuộc gọi
+        - REJECT  : Từ chối cuộc gọi
+        - LEAVE   : Rời cuộc gọi (call vẫn tiếp tục nếu còn người)
+        - HANGUP  : Kết thúc cuộc gọi
+        """
     )
     @PostMapping
     public ResponseEntity<Void> sendSignal(

--- a/src/main/java/org/ping_me/dto/request/call/SignalingPayload.java
+++ b/src/main/java/org/ping_me/dto/request/call/SignalingPayload.java
@@ -1,0 +1,16 @@
+package org.ping_me.dto.request.call;
+
+import lombok.Data;
+
+/**
+ * @author Le Tran Gia Huy
+ * @created 19/04/2026 - 9:34 AM
+ * @project PingMe-Auth-Service
+ * @package org.ping_me.dto.request.call
+ */
+@Data
+public class SignalingPayload {
+    private String callType;      // "AUDIO" | "VIDEO"
+    private String reason;        // Dùng cho REJECT/HANGUP: "BUSY", "DECLINED", "NO_ANSWER"
+    // Nếu sau này cần thêm gì (custom data Zego, etc.) thì mở rộng ở đây
+}

--- a/src/main/java/org/ping_me/dto/request/call/SignalingRequest.java
+++ b/src/main/java/org/ping_me/dto/request/call/SignalingRequest.java
@@ -12,5 +12,6 @@ import lombok.Data;
 public class SignalingRequest {
     private Long roomId;
     private String type; // "OFFER", "ANSWER", "CANDIDATE", "HANGUP"
-    private Object payload; // SDP hoặc Candidate object
+    private String callSessionId;
+    private SignalingPayload payload;
 }

--- a/src/main/java/org/ping_me/dto/response/call/SignalingResponse.java
+++ b/src/main/java/org/ping_me/dto/response/call/SignalingResponse.java
@@ -2,6 +2,7 @@ package org.ping_me.dto.response.call;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import org.ping_me.dto.request.call.SignalingPayload;
 
 /**
  * @author Le Tran Gia Huy
@@ -14,6 +15,11 @@ import lombok.Data;
 public class SignalingResponse {
     private String type;
     private Long senderId; // Quan trọng: Để FE biết ai đang gọi
+    private String senderName;    // FE khỏi phải lookup thêm
     private Long roomId;
-    private Object payload;
+    private String callSessionId; // Quan trọng cho N-N: FE dùng để match đúng session
+    // Snapshot tại thời điểm gửi signal
+    // FE dùng để hiển thị "3 người đang trong call"
+    private Integer activeParticipantCount;
+    private SignalingPayload payload;
 }

--- a/src/main/java/org/ping_me/service/call/impl/SignalingServiceImpl.java
+++ b/src/main/java/org/ping_me/service/call/impl/SignalingServiceImpl.java
@@ -1,17 +1,24 @@
 package org.ping_me.service.call.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.ping_me.dto.request.call.SignalingPayload;
 import org.ping_me.dto.request.call.SignalingRequest;
 import org.ping_me.dto.response.call.SignalingResponse;
 import org.ping_me.model.common.RoomMemberId;
 import org.ping_me.repository.jpa.chat.RoomParticipantRepository;
 import org.ping_me.service.call.SignalingService;
 import org.ping_me.service.user.CurrentUserProvider;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -21,57 +28,200 @@ public class SignalingServiceImpl implements SignalingService {
     private final SimpMessagingTemplate messagingTemplate;
     private final RoomParticipantRepository roomParticipantRepository;
     private final CurrentUserProvider currentUserProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private static final Duration SESSION_TTL = Duration.ofHours(1);
+    private static final String PARTICIPANTS_KEY = "callSession:%s:participants";
+    private static final String META_KEY        = "callSession:%s:meta";
+    private static final String SIGNALING_QUEUE = "/queue/signaling";
 
     @Override
     public void processSignaling(SignalingRequest request) {
         var currentUser = currentUserProvider.get();
-        Long senderId = currentUser.getId();
-        Long roomId = request.getRoomId();
-        String type = request.getType();
+        Long   senderId   = currentUser.getId();
+        String senderName = currentUser.getName();
+        Long   roomId     = request.getRoomId();
+        String type       = request.getType();
+        String sessionId  = request.getCallSessionId();
 
-        log.info("SIGNALING: {} | From: {} | Room: {}", type, senderId, roomId);
+        log.info("SIGNALING: {} | From: {} ({}) | Room: {} | Session: {}",
+                type, senderId, senderName, roomId, sessionId);
 
-        // 1. Kiểm tra thành viên (Relax logic: Nếu là REJECT/HANGUP thì bỏ qua check lỗi)
-        var roomMemberId = new RoomMemberId(roomId, senderId);
-        boolean isMember = roomParticipantRepository.existsById(roomMemberId);
+        // ── 1. Guard: callSessionId bắt buộc với các type cần state ──────────
+        boolean requiresSession = switch (type) {
+            case "INVITE", "ACCEPT", "LEAVE", "HANGUP" -> true;
+            default -> false;
+        };
 
-        if (!isMember) {
-            // Nếu không phải thành viên mà cố tình gửi INVITE/OFFER -> Chặn
-            if (!"REJECT".equals(type) && !"HANGUP".equals(type)) {
-                log.warn("User {} blocked from sending {} to room {}", senderId, type, roomId);
-                // throw new AccessDeniedException("Bạn không thuộc phòng chat này"); // Tạm comment để debug
-                // Thay vì throw lỗi làm crash client, ta log warning và return để tránh treo
-                return;
-            }
-            log.warn("User {} is not in room {} but allowing {} signal to cleanup", senderId, roomId, type);
-        }
-
-        // 2. Tìm người nhận (Target)
-        // Logic cũ: Tìm 1 người còn lại.
-        // Logic mới (An toàn hơn): Lấy danh sách tất cả, trừ mình ra, gửi hết (hỗ trợ cả Group Call sau này)
-        List<Long> otherParticipantIds = roomParticipantRepository.findAllUserIdsInRoomExcept(roomId, senderId);
-
-        if (otherParticipantIds.isEmpty()) {
-            log.warn("No participants found in room {} to send signal", roomId);
+        if (requiresSession && (sessionId == null || sessionId.isBlank())) {
+            log.warn("Signal {} từ user {} thiếu callSessionId — bỏ qua", type, senderId);
             return;
         }
 
-        // 3. Chuẩn bị Payload
+        // ── 2. Kiểm tra thành viên phòng ─────────────────────────────────────
+        boolean isMember = roomParticipantRepository
+                .existsById(new RoomMemberId(roomId, senderId));
+
+        if (!isMember) {
+            boolean isCleanupSignal = switch (type) {
+                case "REJECT", "HANGUP", "LEAVE" -> true;
+                default -> false;
+            };
+            if (!isCleanupSignal) {
+                log.warn("User {} bị chặn khi gửi {} vào room {}", senderId, type, roomId);
+                throw new AccessDeniedException("Bạn không thuộc phòng chat này");
+            }
+            log.warn("User {} không trong room {} nhưng cho phép {} để cleanup",
+                    senderId, roomId, type);
+        }
+
+        // ── 3. Xử lý Redis theo từng loại signal ─────────────────────────────
+        int activeParticipantCount = 0;
+
+        try {
+            activeParticipantCount = switch (type) {
+                case "INVITE"  -> handleInvite(sessionId, senderId, roomId, request.getPayload());
+                case "ACCEPT"  -> handleAccept(sessionId, senderId, senderName, roomId);
+                case "LEAVE"   -> handleLeave(sessionId, senderId);
+                case "HANGUP"  -> handleHangup(sessionId);
+                default        -> 0; // REJECT — không cần Redis
+            };
+        } catch (SessionEndedException e) {
+            // Session đã hết hạn khi user cố ACCEPT → thông báo ngược lại cho người gửi
+            log.warn("Session {} đã kết thúc, user {} không thể join", sessionId, senderId);
+            sendToUser(senderId, new SignalingResponse(
+                    "SESSION_ENDED", senderId, senderName, roomId, sessionId, 0, null));
+            return;
+        } catch (Exception e) {
+            log.error("Lỗi xử lý Redis cho signal {} session {}: {}", type, sessionId, e.getMessage());
+            // Không chặn signal, vẫn forward để FE không bị treo
+        }
+
+        // ── 4. Tìm người nhận ────────────────────────────────────────────────
+        List<Long> otherParticipantIds =
+                roomParticipantRepository.findAllUserIdsInRoomExcept(roomId, senderId);
+
+        if (otherParticipantIds.isEmpty()) {
+            log.warn("Không tìm thấy người nhận trong room {}", roomId);
+            return;
+        }
+        if ("INVITE".equals(type)) {
+            activeParticipantCount = otherParticipantIds.size() + 1;
+        }
+
+        // ── 5. Build response và broadcast ───────────────────────────────────
         SignalingResponse response = new SignalingResponse(
                 type,
                 senderId,
+                senderName,
                 roomId,
+                sessionId,
+                activeParticipantCount,
                 request.getPayload()
         );
 
-        // 4. Gửi cho tất cả những người còn lại trong phòng (thường chỉ có 1 người nếu là 1-1)
         for (Long targetId : otherParticipantIds) {
-            log.info("-> Forwarding signal to User {}", targetId);
-            messagingTemplate.convertAndSendToUser(
-                    String.valueOf(targetId),
-                    "/queue/signaling",
-                    response
-            );
+            log.info("-> Forwarding {} | Session {} -> User {}", type, sessionId, targetId);
+            sendToUser(targetId, response);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Private Handlers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private int handleInvite(String sessionId, Long senderId, Long roomId,
+                             SignalingPayload payload) {
+        String participantsKey = PARTICIPANTS_KEY.formatted(sessionId);
+        String metaKey         = META_KEY.formatted(sessionId);
+
+        // Tạo Set participants, thêm người khởi tạo
+        redisTemplate.opsForSet().add(participantsKey, String.valueOf(senderId));
+        redisTemplate.expire(participantsKey, SESSION_TTL);
+
+        // Lưu meta
+        try {
+            String callType = payload != null ? payload.getCallType() : "VIDEO";
+            String meta = objectMapper.writeValueAsString(Map.of(
+                    "roomId",   roomId,
+                    "status",   "ONGOING",
+                    "callType", callType != null ? callType : "VIDEO"
+            ));
+            redisTemplate.opsForValue().set(metaKey, meta, SESSION_TTL);
+        } catch (JsonProcessingException e) {
+            log.warn("Không thể serialize meta cho session {}", sessionId);
+        }
+
+        log.info("Session {} CREATED | Room: {} | Initiator: {}", sessionId, roomId, senderId);
+        return 1; // Chỉ có người gọi, chưa ai accept
+    }
+
+    private int handleAccept(String sessionId, Long senderId,
+                             String senderName, Long roomId) {
+        String participantsKey = PARTICIPANTS_KEY.formatted(sessionId);
+
+        // Validate session còn sống không
+        Boolean sessionExists = redisTemplate.hasKey(participantsKey);
+        if (Boolean.FALSE.equals(sessionExists)) {
+            throw new SessionEndedException(sessionId);
+        }
+
+        // Thêm vào Set (SADD tự bỏ qua nếu đã có → an toàn khi reconnect)
+        redisTemplate.opsForSet().add(participantsKey, String.valueOf(senderId));
+
+        // Reset TTL mỗi khi có người mới join
+        redisTemplate.expire(participantsKey, SESSION_TTL);
+        redisTemplate.expire(META_KEY.formatted(sessionId), SESSION_TTL);
+
+        Long count = redisTemplate.opsForSet().size(participantsKey);
+        int activeCount = count != null ? count.intValue() : 1;
+
+        log.info("Session {} | User {} JOINED | Active: {}", sessionId, senderId, activeCount);
+        return activeCount;
+    }
+
+    private int handleLeave(String sessionId, Long senderId) {
+        String participantsKey = PARTICIPANTS_KEY.formatted(sessionId);
+
+        redisTemplate.opsForSet().remove(participantsKey, String.valueOf(senderId));
+        Long remaining = redisTemplate.opsForSet().size(participantsKey);
+        int remainingCount = remaining != null ? remaining.intValue() : 0;
+
+        if (remainingCount == 0) {
+            redisTemplate.delete(participantsKey);
+            redisTemplate.delete(META_KEY.formatted(sessionId));
+            log.info("Session {} ENDED — người cuối cùng ({}) đã rời", sessionId, senderId);
+        } else {
+            log.info("Session {} | User {} LEFT | Còn lại: {}", sessionId, senderId, remainingCount);
+        }
+
+        return remainingCount;
+    }
+
+    private int handleHangup(String sessionId) {
+        redisTemplate.delete(PARTICIPANTS_KEY.formatted(sessionId));
+        redisTemplate.delete(META_KEY.formatted(sessionId));
+        log.info("Session {} FORCE ENDED (HANGUP)", sessionId);
+        return 0;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private void sendToUser(Long userId, SignalingResponse response) {
+        messagingTemplate.convertAndSendToUser(
+                String.valueOf(userId),
+                SIGNALING_QUEUE,
+                response
+        );
+    }
+
+    // Exception nội bộ — chỉ dùng trong service này
+    private static class SessionEndedException extends RuntimeException {
+        SessionEndedException(String sessionId) {
+            super("Session ended: " + sessionId);
         }
     }
 }

--- a/src/main/java/org/ping_me/service/chat/impl/MessageServiceImpl.java
+++ b/src/main/java/org/ping_me/service/chat/impl/MessageServiceImpl.java
@@ -116,7 +116,7 @@ public class MessageServiceImpl implements MessageService {
     // index increase -> newest messages
     //
     //
-    // Kkhông sửa cấu trúc này
+    // Không sửa cấu trúc này
 
     /* ========================================================================== */
     /*                         CÁC HÀM XỬ LÝ GỬI TIN NHẮN                         */


### PR DESCRIPTION
Add call session management using Redis for signaling. This includes:
- Storing active participants and session metadata in Redis.
- Handling INVITE, ACCEPT, LEAVE, and HANGUP signaling types.
- Broadcasting signals to relevant participants.
- Refactor SignalingController to use new service.