### PR TITLE
fix(room): Clean up deleted messages on room dissolution

### DIFF
--- a/src/main/java/org/ping_me/repository/jpa/chat/DeletedMessageRepository.java
+++ b/src/main/java/org/ping_me/repository/jpa/chat/DeletedMessageRepository.java
@@ -12,4 +12,6 @@ public interface DeletedMessageRepository extends JpaRepository<DeletedMessage, 
     boolean existsByIdRoomIdAndIdUserId(Long roomId, Long userId);
 
     List<DeletedMessage> findByIdRoomIdAndIdUserId(Long roomId, Long userId);
+
+    long deleteByIdRoomId(Long roomId);
 }

--- a/src/main/java/org/ping_me/service/chat/impl/RoomServiceImpl.java
+++ b/src/main/java/org/ping_me/service/chat/impl/RoomServiceImpl.java
@@ -13,6 +13,7 @@ import org.ping_me.model.common.RoomMemberId;
 import org.ping_me.model.constant.RoomRole;
 import org.ping_me.model.constant.RoomType;
 import org.ping_me.repository.jpa.auth.UserRepository;
+import org.ping_me.repository.jpa.chat.DeletedMessageRepository;
 import org.ping_me.repository.jpa.chat.RoomParticipantRepository;
 import org.ping_me.repository.jpa.chat.RoomRepository;
 import org.ping_me.service.chat.MessageService;
@@ -53,6 +54,7 @@ public class RoomServiceImpl implements RoomService {
     // REPOSITORY
     private final RoomRepository roomRepository;
     private final RoomParticipantRepository roomParticipantRepository;
+    private final DeletedMessageRepository deletedMessageRepository;
     private final UserRepository userRepository;
 
     // PUBLISHER
@@ -367,6 +369,8 @@ public class RoomServiceImpl implements RoomService {
         requireOwner(caller, "Chỉ trưởng nhóm mới có quyền giải tán nhóm");
 
         var participants = roomParticipantRepository.findByRoom_Id(roomId);
+        // "Delete for me" records keep FK(room_id -> rooms.id). Must clean them first.
+        deletedMessageRepository.deleteByIdRoomId(roomId);
         roomParticipantRepository.deleteAll(participants);
         roomRepository.delete(room);
 


### PR DESCRIPTION
Clean up deleted message records associated with a room when it is dissolved. Add `deleteByIdRoomId` to DeletedMessageRepository. Add `deletedMessageRepository` dependency to RoomServiceImpl.