### PR TITLE
feat(messages): Add AI summary for group chat messages

### DIFF
--- a/src/main/java/org/ping_me/controller/chat/MessageController.java
+++ b/src/main/java/org/ping_me/controller/chat/MessageController.java
@@ -19,6 +19,7 @@ import org.ping_me.dto.request.chat.message.SendMessageRequest;
 import org.ping_me.dto.request.chat.message.SendWeatherMessageRequest;
 import org.ping_me.dto.request.chat.message.VotePollRequest;
 import org.ping_me.dto.response.chat.message.HistoryMessageResponse;
+import org.ping_me.dto.response.chat.message.GroupMessageSummaryResponse;
 import org.ping_me.dto.response.chat.message.MessageRecalledResponse;
 import org.ping_me.dto.response.chat.message.MessageResponse;
 import org.ping_me.dto.response.chat.message.ReadStateResponse;
@@ -304,6 +305,20 @@ public class    MessageController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(new ApiResponse<>(messageService.getPinnedMessages(roomId)));
+    }
+
+    @Operation(
+            summary = "Tóm tắt AI 20 tin nhắn gần nhất của nhóm",
+            description = "Chỉ áp dụng cho phòng chat nhóm mà user hiện tại là thành viên"
+    )
+    @GetMapping("/summary")
+    public ResponseEntity<ApiResponse<GroupMessageSummaryResponse>> summarizeLatestGroupMessages(
+            @Parameter(description = "ID phòng chat nhóm", example = "1", required = true)
+            @RequestParam Long roomId
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new ApiResponse<>(messageService.summarizeLatestGroupMessages(roomId)));
     }
 
     // ================= MARK READ =================

--- a/src/main/java/org/ping_me/dto/response/chat/message/GroupMessageSummaryResponse.java
+++ b/src/main/java/org/ping_me/dto/response/chat/message/GroupMessageSummaryResponse.java
@@ -1,0 +1,17 @@
+package org.ping_me.dto.response.chat.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GroupMessageSummaryResponse {
+    private Long roomId;
+    private Integer summarizedMessageCount;
+    private String summary;
+    private LocalDateTime generatedAt;
+}

--- a/src/main/java/org/ping_me/service/chat/MessageService.java
+++ b/src/main/java/org/ping_me/service/chat/MessageService.java
@@ -10,6 +10,7 @@ import org.ping_me.dto.request.chat.message.SendWeatherMessageRequest;
 import org.ping_me.dto.request.chat.message.VotePollRequest;
 import org.ping_me.dto.response.chat.message.HistoryMessageResponse;
 import org.ping_me.dto.response.chat.message.DeletedMessageResponse;
+import org.ping_me.dto.response.chat.message.GroupMessageSummaryResponse;
 import org.ping_me.dto.response.chat.message.MessageRecalledResponse;
 import org.ping_me.dto.response.chat.message.MessageResponse;
 import org.ping_me.dto.response.chat.message.ReadStateResponse;
@@ -70,6 +71,8 @@ public interface MessageService {
     HistoryMessageResponse getHistoryMessages(
             Long roomId, String beforeId, Integer size
     );
+
+    GroupMessageSummaryResponse summarizeLatestGroupMessages(Long roomId);
 
     Message createSystemMessage(Room room, String content, User user);
 }

--- a/src/main/java/org/ping_me/service/chat/impl/MessageServiceImpl.java
+++ b/src/main/java/org/ping_me/service/chat/impl/MessageServiceImpl.java
@@ -18,6 +18,7 @@ import org.ping_me.dto.request.chat.message.SendMessageRequest;
 import org.ping_me.dto.request.chat.message.SendWeatherMessageRequest;
 import org.ping_me.dto.request.chat.message.VotePollRequest;
 import org.ping_me.dto.response.chat.message.DeletedMessageResponse;
+import org.ping_me.dto.response.chat.message.GroupMessageSummaryResponse;
 import org.ping_me.dto.response.chat.message.HistoryMessageResponse;
 import org.ping_me.dto.response.chat.message.MessageRecalledResponse;
 import org.ping_me.dto.response.chat.message.MessageResponse;
@@ -33,10 +34,12 @@ import org.ping_me.model.chat.RoomParticipant;
 import org.ping_me.model.common.DeletedMessageId;
 import org.ping_me.model.common.RoomMemberId;
 import org.ping_me.model.constant.MessageType;
+import org.ping_me.model.constant.RoomType;
 import org.ping_me.repository.jpa.chat.DeletedMessageRepository;
 import org.ping_me.repository.jpa.chat.RoomParticipantRepository;
 import org.ping_me.repository.jpa.chat.RoomRepository;
 import org.ping_me.repository.mongodb.chat.MessageRepository;
+import org.ping_me.utils.AIChatHelper;
 import org.ping_me.service.chat.MessageCachingService;
 import org.ping_me.service.chat.MessageService;
 import org.ping_me.service.chat.event.message.MessageCreatedEvent;
@@ -54,7 +57,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -100,6 +102,7 @@ public class MessageServiceImpl implements MessageService {
     // UTILS
     private final ObjectMapper objectMapper;
     private final ChatMapper chatMapper;
+    private final AIChatHelper aiChatHelper;
 
     @NonFinal
     @Value("${spring.kafka.topic.user-chat-dev}")
@@ -712,6 +715,76 @@ public class MessageServiceImpl implements MessageService {
                 .toList();
     }
 
+    @Override
+    public GroupMessageSummaryResponse summarizeLatestGroupMessages(Long roomId) {
+        var currentUser = currentUserProvider.get();
+        Long currentUserId = currentUser.getId();
+
+        Room room = roomRepository
+                .findById(roomId)
+                .orElseThrow(() -> new EntityNotFoundException("Phòng chat này không tồn tại"));
+
+        if (room.getRoomType() != RoomType.GROUP) {
+            throw new IllegalArgumentException("Tính năng tóm tắt chỉ hỗ trợ phòng chat nhóm");
+        }
+
+        validateRoomMember(roomId, currentUserId);
+
+        Set<String> deletedMessageIds = getDeletedMessageIds(roomId, currentUserId);
+        List<Message> latestMessages = messageRepository
+                .findByRoomIdOrderByIdDesc(roomId, PageRequest.of(0, 60))
+                .stream()
+                .filter(Message::isActive)
+                .filter(message -> !deletedMessageIds.contains(message.getId()))
+                .limit(20)
+                .toList();
+
+        if (latestMessages.isEmpty()) {
+            return new GroupMessageSummaryResponse(
+                    roomId,
+                    0,
+                    "Nhóm chưa có đủ nội dung để tóm tắt.",
+                    LocalDateTime.now()
+            );
+        }
+
+        Map<Long, String> participantNames = roomParticipantRepository
+                .findByRoom_Id(roomId)
+                .stream()
+                .collect(Collectors.toMap(
+                        participant -> participant.getUser().getId(),
+                        participant -> participant.getUser().getName(),
+                        (left, right) -> left
+                ));
+
+        List<Message> chronologicallySorted = new ArrayList<>(latestMessages);
+        Collections.reverse(chronologicallySorted);
+
+        StringBuilder conversation = new StringBuilder();
+        for (Message message : chronologicallySorted) {
+            String senderName = participantNames.getOrDefault(message.getSenderId(), "Thành viên");
+            conversation
+                    .append("- [")
+                    .append(senderName)
+                    .append("] ")
+                    .append(formatSummaryMessageContent(message))
+                    .append("\n");
+        }
+
+        String prompt = buildGroupSummaryPrompt(conversation.toString());
+        String summary = aiChatHelper.useAi(prompt, List.of(), "gpt-4o-mini", 600);
+        if (summary == null || summary.isBlank()) {
+            summary = "Chưa thể tạo tóm tắt ở thời điểm hiện tại.";
+        }
+
+        return new GroupMessageSummaryResponse(
+                roomId,
+                chronologicallySorted.size(),
+                summary.trim(),
+                LocalDateTime.now()
+        );
+    }
+
     private void validatePollRequest(CreatePollMessageRequest request) {
         if (request.getOptions() == null || request.getOptions().size() < 2) {
             throw new IllegalArgumentException("Bình chọn cần ít nhất 2 lựa chọn");
@@ -1268,6 +1341,47 @@ public class MessageServiceImpl implements MessageService {
         }
 
         return null;
+    }
+
+    private String buildGroupSummaryPrompt(String conversation) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Bạn là trợ lý tóm tắt cuộc trò chuyện nhóm của ứng dụng PingMe.\n");
+        sb.append("Hãy đọc 20 tin nhắn gần nhất và tóm tắt bằng tiếng Việt, ngắn gọn, dễ hiểu.\n");
+        sb.append("Yêu cầu:\n");
+        sb.append("1) 1 đoạn tóm tắt chính (tối đa 3 câu).\n");
+        sb.append("2) 2-4 gạch đầu dòng về các điểm quan trọng hoặc việc cần chú ý.\n");
+        sb.append("3) Không bịa thêm thông tin ngoài đoạn hội thoại.\n");
+        sb.append("4) Không dùng markdown code block.\n\n");
+        sb.append("Hội thoại:\n");
+        sb.append(conversation);
+        return sb.toString();
+    }
+
+    private String formatSummaryMessageContent(Message message) {
+        if (message.getType() == MessageType.TEXT || message.getType() == MessageType.SYSTEM) {
+            return message.getContent() == null || message.getContent().isBlank()
+                    ? "(Tin nhắn trống)"
+                    : message.getContent();
+        }
+        if (message.getType() == MessageType.IMAGE) {
+            return "(Đã gửi hình ảnh)";
+        }
+        if (message.getType() == MessageType.VIDEO) {
+            return "(Đã gửi video)";
+        }
+        if (message.getType() == MessageType.FILE) {
+            return "(Đã gửi tệp đính kèm)";
+        }
+        if (message.getType() == MessageType.WEATHER) {
+            return "(Đã gửi thông tin thời tiết)";
+        }
+        if (message.getType() == MessageType.POLL) {
+            if (message.getPoll() != null && message.getPoll().getQuestion() != null) {
+                return "Bình chọn: " + message.getPoll().getQuestion();
+            }
+            return "(Đã tạo bình chọn)";
+        }
+        return "(Tin nhắn không xác định)";
     }
 
     // Sửa lại tham số nhận vào là User thay vì chỉ senderId


### PR DESCRIPTION
Integrate AI summarization for the latest 20 group chat messages. This introduces a new API endpoint /messages/summary to retrieve an AI-generated summary of recent group conversations, improving user experience by providing quick overviews. Added `GroupMessageSummaryResponse` DTO and updated `MessageService` and `MessageController` to support this feature. Includes logic to filter out deleted messages and format message content for AI processing.