### PR TITLE
feat(service): Add friendship query API

### DIFF
--- a/src/main/java/org/ping_me/config/security/SecurityConfiguration.java
+++ b/src/main/java/org/ping_me/config/security/SecurityConfiguration.java
@@ -1,6 +1,5 @@
 package org.ping_me.config.security;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -8,10 +7,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import java.util.Arrays;
 
 /**
  * Admin 8/3/2025
@@ -19,54 +14,50 @@ import java.util.Arrays;
 @Configuration
 public class SecurityConfiguration {
 
-    private static final String[] WHITELIST = {
-            // API DOCS
-            "/swagger-ui/**",
-            "/v3/api-docs/**",
+        private static final String[] WHITELIST = {
+                        // API DOCS
+                        "/swagger-ui/**",
+                        "/v3/api-docs/**",
 
-            // WebSocket
-            "/core-service/ws/**",
+                        // WebSocket
+                        "/core-service/ws/**",
 
-            // Health check
-            "/actuator/health",
-            "/actuator/health/**",
+                        // Health check
+                        "/actuator/health",
+                        "/actuator/health/**",
+                        "/core-service/users/**",
 
-            // Spring Boot error dispatch
-            "/error"
-    };
+                        // Spring Boot error dispatch
+                        "/error"
+        };
 
-    @Bean
-    public SecurityFilterChain securityFilterChain(
-            HttpSecurity httpSecurity,
-            CustomAuthenticationEntryPoint customAuthenticationEntryPoint,
-            CustomAccessDeniedHandler customAccessDeniedHandler
-    ) throws Exception {
-        httpSecurity
-                // 1. TẮT CORS (Gateway đã thầu vụ này rồi)
-                .cors(AbstractHttpConfigurer::disable)
+        @Bean
+        public SecurityFilterChain securityFilterChain(
+                        HttpSecurity httpSecurity,
+                        CustomAuthenticationEntryPoint customAuthenticationEntryPoint,
+                        CustomAccessDeniedHandler customAccessDeniedHandler) throws Exception {
+                httpSecurity
+                                // 1. TẮT CORS (Gateway đã thầu vụ này rồi)
+                                .cors(AbstractHttpConfigurer::disable)
 
-                .csrf(AbstractHttpConfigurer::disable)
-                .formLogin(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable)
+                                .csrf(AbstractHttpConfigurer::disable)
+                                .formLogin(AbstractHttpConfigurer::disable)
+                                .httpBasic(AbstractHttpConfigurer::disable)
 
-                .sessionManagement(session -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                )
+                                .sessionManagement(session -> session
+                                                .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(WHITELIST).permitAll()
-                        .anyRequest().authenticated()
-                )
+                                .authorizeHttpRequests(auth -> auth
+                                                .requestMatchers(WHITELIST).permitAll()
+                                                .anyRequest().authenticated())
 
-                // 2. Cấu hình JWT mặc định
-                .oauth2ResourceServer(oauth2 -> oauth2
-                        .jwt(Customizer.withDefaults())
-                        .authenticationEntryPoint(customAuthenticationEntryPoint)
-                )
-                .exceptionHandling(exception -> exception
-                        .accessDeniedHandler(customAccessDeniedHandler)
-                );
+                                // 2. Cấu hình JWT mặc định
+                                .oauth2ResourceServer(oauth2 -> oauth2
+                                                .jwt(Customizer.withDefaults())
+                                                .authenticationEntryPoint(customAuthenticationEntryPoint))
+                                .exceptionHandling(exception -> exception
+                                                .accessDeniedHandler(customAccessDeniedHandler));
 
-        return httpSecurity.build();
-    }
+                return httpSecurity.build();
+        }
 }

--- a/src/main/java/org/ping_me/controller/user/UserFriendshipQueryController.java
+++ b/src/main/java/org/ping_me/controller/user/UserFriendshipQueryController.java
@@ -1,0 +1,33 @@
+package org.ping_me.controller.user;
+
+import lombok.RequiredArgsConstructor;
+import org.ping_me.service.user.UserFriendshipQueryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Simple query API used by other services to check friendship between two
+ * users.
+ */
+@RestController
+@RequestMapping("/core-service/users")
+@RequiredArgsConstructor
+public class UserFriendshipQueryController {
+
+    private final UserFriendshipQueryService userFriendshipQueryService;
+
+    @GetMapping("/{hostUserId}/is-friend/{userId}")
+    public ResponseEntity<Boolean> isFriend(
+            @PathVariable Long hostUserId,
+            @PathVariable Long userId) {
+        return ResponseEntity.ok(userFriendshipQueryService.isFriend(hostUserId, userId));
+    }
+
+    @GetMapping("/{userId}/friend-ids")
+    public ResponseEntity<java.util.List<Long>> getFriendIds(@PathVariable Long userId) {
+        return ResponseEntity.ok(userFriendshipQueryService.getFriendIds(userId));
+    }
+}

--- a/src/main/java/org/ping_me/service/user/UserFriendshipQueryService.java
+++ b/src/main/java/org/ping_me/service/user/UserFriendshipQueryService.java
@@ -1,0 +1,14 @@
+package org.ping_me.service.user;
+
+import java.util.List;
+
+/**
+ * Query friendship information for user-facing endpoints.
+ */
+public interface UserFriendshipQueryService {
+
+    boolean isFriend(Long hostUserId, Long userId);
+
+    List<Long> getFriendIds(Long userId);
+}
+

--- a/src/main/java/org/ping_me/service/user/impl/UserFriendshipQueryServiceImpl.java
+++ b/src/main/java/org/ping_me/service/user/impl/UserFriendshipQueryServiceImpl.java
@@ -1,0 +1,55 @@
+package org.ping_me.service.user.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.ping_me.model.chat.Friendship;
+import org.ping_me.model.constant.FriendshipStatus;
+import org.ping_me.repository.jpa.chat.FriendshipRepository;
+import org.ping_me.service.user.UserFriendshipQueryService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Query service for friendship lookup endpoints.
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserFriendshipQueryServiceImpl implements UserFriendshipQueryService {
+
+    private final FriendshipRepository friendshipRepository;
+
+    @Override
+    public boolean isFriend(Long hostUserId, Long userId) {
+        if (hostUserId == null || userId == null) {
+            return false;
+        }
+
+        Long low = Math.min(hostUserId, userId);
+        Long high = Math.max(hostUserId, userId);
+
+        return friendshipRepository.findByUserLowIdAndUserHighId(low, high)
+                .map(Friendship::getFriendshipStatus)
+                .filter(status -> status == FriendshipStatus.ACCEPTED)
+                .isPresent();
+    }
+
+    @Override
+    public List<Long> getFriendIds(Long userId) {
+        if (userId == null) {
+            return List.of();
+        }
+
+        return friendshipRepository.findAllByStatusAndUserWithoutBeforeId(
+                        FriendshipStatus.ACCEPTED,
+                        userId
+                )
+                .stream()
+                .map(friendship -> friendship.getUserLowId().equals(userId)
+                        ? friendship.getUserHighId()
+                        : friendship.getUserLowId())
+                .toList();
+    }
+}
+


### PR DESCRIPTION
Introduce new API endpoints for querying user friendship status and retrieving friend IDs.

This commit adds:
- UserFriendshipQueryController for REST endpoints.
- UserFriendshipQueryService interface and its implementation for business logic.
- Updates SecurityConfiguration to whitelist new user friendship query endpoints.