### PR TITLE
feat(core): add chat notes and reminders features

### DIFF
--- a/src/main/java/org/ping_me/dto/request/chat/message/CreateNoteMessageRequest.java
+++ b/src/main/java/org/ping_me/dto/request/chat/message/CreateNoteMessageRequest.java
@@ -1,0 +1,32 @@
+package org.ping_me.dto.request.chat.message;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class CreateNoteMessageRequest {
+
+    @NotBlank(message = "Tiêu đề ghi chú không được để trống")
+    @Length(max = 200, message = "Tiêu đề ghi chú không được vượt quá 200 ký tự")
+    private String title;
+
+    @NotBlank(message = "Nội dung ghi chú không được để trống")
+    @Length(max = 2000, message = "Nội dung ghi chú không được vượt quá 2000 ký tự")
+    private String body;
+
+    private Boolean pinToTop = false;
+
+    private String repliedMessageId;
+
+    @NotBlank(message = "UUID không được để trống")
+    private String clientMsgId;
+
+    @NotNull(message = "Mã phòng không được để trống")
+    private Long roomId;
+}

--- a/src/main/java/org/ping_me/dto/request/chat/message/CreateReminderMessageRequest.java
+++ b/src/main/java/org/ping_me/dto/request/chat/message/CreateReminderMessageRequest.java
@@ -1,0 +1,44 @@
+package org.ping_me.dto.request.chat.message;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class CreateReminderMessageRequest {
+
+    @NotBlank(message = "Tiêu đề nhắc hẹn không được để trống")
+    @Length(max = 200, message = "Tiêu đề nhắc hẹn không được vượt quá 200 ký tự")
+    private String title;
+
+    @NotBlank(message = "Nội dung nhắc hẹn không được để trống")
+    @Length(max = 2000, message = "Nội dung nhắc hẹn không được vượt quá 2000 ký tự")
+    private String body;
+
+    @NotNull(message = "Thời gian nhắc hẹn không được để trống")
+    private LocalDateTime remindAt;
+
+    @NotBlank(message = "Múi giờ không được để trống")
+    @Length(max = 64, message = "Múi giờ không được vượt quá 64 ký tự")
+    private String timezone;
+
+    @Length(max = 32, message = "Kiểu lặp lại không được vượt quá 32 ký tự")
+    private String repeatRule = "NONE";
+
+    private Boolean pinToTop = false;
+
+    private String repliedMessageId;
+
+    @NotBlank(message = "UUID không được để trống")
+    private String clientMsgId;
+
+    @NotNull(message = "Mã phòng không được để trống")
+    private Long roomId;
+}

--- a/src/main/java/org/ping_me/dto/response/chat/message/NoteResponse.java
+++ b/src/main/java/org/ping_me/dto/response/chat/message/NoteResponse.java
@@ -1,0 +1,17 @@
+package org.ping_me.dto.response.chat.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class NoteResponse {
+    private Long id;
+    private String messageId;
+    private Long roomId;
+    private Long createdByUserId;
+    private String title;
+    private String body;
+}

--- a/src/main/java/org/ping_me/dto/response/chat/message/ReminderResponse.java
+++ b/src/main/java/org/ping_me/dto/response/chat/message/ReminderResponse.java
@@ -1,0 +1,27 @@
+package org.ping_me.dto.response.chat.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.ping_me.model.constant.ReminderStatus;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class ReminderResponse {
+    private Long id;
+    private String messageId;
+    private Long roomId;
+    private Long createdByUserId;
+    private String title;
+    private String body;
+    private LocalDateTime remindAt;
+    private String timezone;
+    private String repeatRule;
+    private ReminderStatus status;
+    private LocalDateTime triggeredAt;
+    private LocalDateTime completedAt;
+    private LocalDateTime canceledAt;
+}

--- a/src/main/java/org/ping_me/model/chat/ChatNote.java
+++ b/src/main/java/org/ping_me/model/chat/ChatNote.java
@@ -1,0 +1,59 @@
+package org.ping_me.model.chat;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.ping_me.model.User;
+import org.ping_me.model.common.BaseEntity;
+
+@Entity
+@Table(
+        name = "chat_notes",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_chat_note_message", columnNames = "message_id")
+        },
+        indexes = {
+                @Index(name = "idx_chat_note_room", columnList = "room_id"),
+                @Index(name = "idx_chat_note_created_by", columnList = "created_by_user_id")
+        }
+)
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class ChatNote extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long id;
+
+    @Column(name = "message_id", nullable = false, length = 64)
+    private String messageId;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "room_id", nullable = false)
+    private Room room;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "created_by_user_id", nullable = false)
+    private User createdByUser;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(nullable = false, length = 2000)
+    private String body;
+}

--- a/src/main/java/org/ping_me/model/chat/ChatNote.java
+++ b/src/main/java/org/ping_me/model/chat/ChatNote.java
@@ -1,22 +1,13 @@
 package org.ping_me.model.chat;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Index;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.ping_me.model.User;
-import org.ping_me.model.common.BaseEntity;
 
 @Entity
 @Table(
@@ -33,27 +24,5 @@ import org.ping_me.model.common.BaseEntity;
 @NoArgsConstructor
 @Getter
 @Setter
-public class ChatNote extends BaseEntity {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @EqualsAndHashCode.Include
-    private Long id;
-
-    @Column(name = "message_id", nullable = false, length = 64)
-    private String messageId;
-
-    @ManyToOne(optional = false)
-    @JoinColumn(name = "room_id", nullable = false)
-    private Room room;
-
-    @ManyToOne(optional = false)
-    @JoinColumn(name = "created_by_user_id", nullable = false)
-    private User createdByUser;
-
-    @Column(nullable = false, length = 200)
-    private String title;
-
-    @Column(nullable = false, length = 2000)
-    private String body;
+public class ChatNote extends ChatRoomEntry {
 }

--- a/src/main/java/org/ping_me/model/chat/ChatReminder.java
+++ b/src/main/java/org/ping_me/model/chat/ChatReminder.java
@@ -4,21 +4,13 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Index;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.ping_me.model.User;
-import org.ping_me.model.common.BaseEntity;
 import org.ping_me.model.constant.ReminderStatus;
 
 import java.time.LocalDateTime;
@@ -39,29 +31,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Getter
 @Setter
-public class ChatReminder extends BaseEntity {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @EqualsAndHashCode.Include
-    private Long id;
-
-    @Column(name = "message_id", nullable = false, length = 64)
-    private String messageId;
-
-    @ManyToOne(optional = false)
-    @JoinColumn(name = "room_id", nullable = false)
-    private Room room;
-
-    @ManyToOne(optional = false)
-    @JoinColumn(name = "created_by_user_id", nullable = false)
-    private User createdByUser;
-
-    @Column(nullable = false, length = 200)
-    private String title;
-
-    @Column(nullable = false, length = 2000)
-    private String body;
+public class ChatReminder extends ChatRoomEntry {
 
     @Column(name = "remind_at", nullable = false)
     private LocalDateTime remindAt;

--- a/src/main/java/org/ping_me/model/chat/ChatReminder.java
+++ b/src/main/java/org/ping_me/model/chat/ChatReminder.java
@@ -1,0 +1,87 @@
+package org.ping_me.model.chat;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.ping_me.model.User;
+import org.ping_me.model.common.BaseEntity;
+import org.ping_me.model.constant.ReminderStatus;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "chat_reminders",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_chat_reminder_message", columnNames = "message_id")
+        },
+        indexes = {
+                @Index(name = "idx_chat_reminder_room", columnList = "room_id"),
+                @Index(name = "idx_chat_reminder_due", columnList = "status, remind_at"),
+                @Index(name = "idx_chat_reminder_created_by", columnList = "created_by_user_id")
+        }
+)
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class ChatReminder extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long id;
+
+    @Column(name = "message_id", nullable = false, length = 64)
+    private String messageId;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "room_id", nullable = false)
+    private Room room;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "created_by_user_id", nullable = false)
+    private User createdByUser;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(nullable = false, length = 2000)
+    private String body;
+
+    @Column(name = "remind_at", nullable = false)
+    private LocalDateTime remindAt;
+
+    @Column(nullable = false, length = 64)
+    private String timezone;
+
+    @Column(name = "repeat_rule", nullable = false, length = 32)
+    private String repeatRule = "NONE";
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 24)
+    private ReminderStatus status = ReminderStatus.PENDING;
+
+    @Column(name = "triggered_at")
+    private LocalDateTime triggeredAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @Column(name = "canceled_at")
+    private LocalDateTime canceledAt;
+}

--- a/src/main/java/org/ping_me/model/constant/ReminderStatus.java
+++ b/src/main/java/org/ping_me/model/constant/ReminderStatus.java
@@ -1,0 +1,5 @@
+package org.ping_me.model.constant;
+
+public enum ReminderStatus {
+    PENDING, TRIGGERED, DONE, CANCELED
+}

--- a/src/main/java/org/ping_me/repository/jpa/chat/ChatNoteRepository.java
+++ b/src/main/java/org/ping_me/repository/jpa/chat/ChatNoteRepository.java
@@ -1,0 +1,10 @@
+package org.ping_me.repository.jpa.chat;
+
+import org.ping_me.model.chat.ChatNote;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ChatNoteRepository extends JpaRepository<ChatNote, Long> {
+    Optional<ChatNote> findByMessageId(String messageId);
+}

--- a/src/main/java/org/ping_me/repository/jpa/chat/ChatReminderRepository.java
+++ b/src/main/java/org/ping_me/repository/jpa/chat/ChatReminderRepository.java
@@ -1,0 +1,10 @@
+package org.ping_me.repository.jpa.chat;
+
+import org.ping_me.model.chat.ChatReminder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ChatReminderRepository extends JpaRepository<ChatReminder, Long> {
+    Optional<ChatReminder> findByMessageId(String messageId);
+}


### PR DESCRIPTION
- Create JPA entities ChatNote and ChatReminder with indexes and unique constraints
- Add JpaRepository interfaces for both new entities
- Implement request and response DTOs for notes and reminders
- Add ReminderStatus enum to manage reminder state transitions