### PR TITLE
feat(core): add ChatRoomEntry mapped superclass

### DIFF
--- a/src/main/java/org/ping_me/model/chat/ChatRoomEntry.java
+++ b/src/main/java/org/ping_me/model/chat/ChatRoomEntry.java
@@ -1,0 +1,42 @@
+package org.ping_me.model.chat;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MappedSuperclass;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import org.ping_me.model.User;
+import org.ping_me.model.common.BaseEntity;
+
+@MappedSuperclass
+@Getter
+@Setter
+public abstract class ChatRoomEntry extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long id;
+
+    @Column(name = "message_id", nullable = false, length = 64)
+    private String messageId;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "room_id", nullable = false)
+    private Room room;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "created_by_user_id", nullable = false)
+    private User createdByUser;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(nullable = false, length = 2000)
+    private String body;
+}


### PR DESCRIPTION
Introduce the ChatRoomEntry abstract class to serve as a base entity for chat room entries, containing common fields such as message ID, room, creator, title, and body.