### PR TITLE
feat(core): implement scheduled chat reminder triggers

### DIFF
--- a/src/main/java/org/ping_me/PingMeCoreServiceApplication.java
+++ b/src/main/java/org/ping_me/PingMeCoreServiceApplication.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 
@@ -19,6 +20,7 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 @EnableMongoRepositories(basePackages = "org.ping_me.repository.mongodb")
 @EnableFeignClients
 @EnableAsync
+@EnableScheduling
 @EnableMethodSecurity
 public class PingMeCoreServiceApplication {
 

--- a/src/main/java/org/ping_me/repository/jpa/chat/ChatReminderRepository.java
+++ b/src/main/java/org/ping_me/repository/jpa/chat/ChatReminderRepository.java
@@ -1,10 +1,20 @@
 package org.ping_me.repository.jpa.chat;
 
 import org.ping_me.model.chat.ChatReminder;
+import org.ping_me.model.constant.ReminderStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface ChatReminderRepository extends JpaRepository<ChatReminder, Long> {
     Optional<ChatReminder> findByMessageId(String messageId);
+
+    List<ChatReminder> findByStatusAndRemindAtLessThanEqual(
+            ReminderStatus status,
+            LocalDateTime remindAt,
+            Pageable pageable
+    );
 }

--- a/src/main/java/org/ping_me/service/chat/impl/ChatReminderScheduler.java
+++ b/src/main/java/org/ping_me/service/chat/impl/ChatReminderScheduler.java
@@ -1,0 +1,54 @@
+package org.ping_me.service.chat.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.ping_me.model.chat.ChatReminder;
+import org.ping_me.model.constant.ReminderStatus;
+import org.ping_me.repository.jpa.chat.ChatReminderRepository;
+import org.ping_me.repository.mongodb.chat.MessageRepository;
+import org.ping_me.service.chat.event.message.MessageUpdatedEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChatReminderScheduler {
+
+    private static final int BATCH_SIZE = 100;
+
+    private final ChatReminderRepository chatReminderRepository;
+    private final MessageRepository messageRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Scheduled(fixedDelayString = "${app.chat.reminders.scan-delay-ms:10000}")
+    @Transactional
+    public void triggerDueReminders() {
+        var now = LocalDateTime.now();
+        var dueReminders = chatReminderRepository.findByStatusAndRemindAtLessThanEqual(
+                ReminderStatus.PENDING,
+                now,
+                PageRequest.of(0, BATCH_SIZE)
+        );
+
+        for (ChatReminder reminder : dueReminders) {
+            triggerReminder(reminder, now);
+        }
+    }
+
+    private void triggerReminder(ChatReminder reminder, LocalDateTime triggeredAt) {
+        reminder.setStatus(ReminderStatus.TRIGGERED);
+        reminder.setTriggeredAt(triggeredAt);
+
+        messageRepository.findById(reminder.getMessageId())
+                .ifPresentOrElse(
+                        message -> eventPublisher.publishEvent(new MessageUpdatedEvent(message)),
+                        () -> log.warn("Reminder {} has missing message {}", reminder.getId(), reminder.getMessageId())
+                );
+    }
+}


### PR DESCRIPTION
- Enable scheduling using `@EnableScheduling` on the core application.
- Add `ChatReminderScheduler` to fetch pending reminders and trigger them in batches.
- Update `ChatReminderRepository` with custom query to find due reminders.
- Publish `MessageUpdatedEvent` when reminders are triggered.